### PR TITLE
Configurable floating Auto Fill button position (v1.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased 1.x.x] — started 2026-03-09
 
+## 1.3.2 — 2026-07-24
+
+- Floating **Auto Fill** button corner can be chosen from the popup Fill tab (bottom-right, bottom-left, top-right, top-left).
+- Edge gap controls show only the sides relevant to the chosen corner (e.g. bottom + right for bottom-right); values persist in `chrome.storage.local` and update the on-page button immediately when it is already injected.
+
 ## 1.3.1 — 2026-07-08
 
 - Per-entry `chrome.storage.local` storage with one-time migration from sync, fixing silent save failures when five or more context configurations exceeded Chrome sync storage's 8 KB per-item limit.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ You define pairs of **CSS selector → value template**, and the extension fills
 ## 🚀 How to Use
 
 ### Option A — Floating button on the page
-If you have custom rules configured for the current page, a purple **\"Auto Fill\"** button appears in the bottom-right corner.  
-Click it to run your rules and fill matching fields.
+If you have custom rules configured for the current page, a purple **\"Auto Fill\"** button is injected on the page (bottom-right by default).  
+On the popup **Fill** tab you can choose its corner (bottom-right, bottom-left, top-right, top-left) and set edge gaps in pixels for the relevant sides.  
+Click the button to run your rules and fill matching fields.
 
 ### Option B — Extension popup
 Click the extension icon in Chrome's toolbar. The popup has three main areas:

--- a/TESTS.md
+++ b/TESTS.md
@@ -26,7 +26,7 @@ Short description: Trigger a fill run for the active tab using the popup `Fill F
 
 Short description: The Fill tab hints that a floating Auto Fill button may be injected on the page.
 
-- [ ] Open the popup on a page where custom selectors are configured (see Custom Rules feature) and confirm the hint text mentions the floating Auto Fill button in the bottom‑right corner.
+- [ ] Open the popup on a page where custom selectors are configured (see Custom Rules feature) and confirm the hint text mentions the configurable floating **Auto Fill** button and corner/gap controls on the Fill tab.
 - [ ] On a fresh install or a page where no context config exists, confirm the hint text is still present and does not contradict actual behavior (mark specifics as **TBD** during first test run).
 
 ## Popup – Fields Tab
@@ -167,7 +167,10 @@ Short description: Under safe conditions, leaving the Custom tab triggers an aut
 
 Short description: Inject a floating Auto Fill button on pages that have context configurations and a ready DOM.
 
-- [ ] On a page where custom context configuration exists (custom selectors and/or vars), reload the page and verify that a floating **Auto Fill** button appears in the bottom‑right corner.
+- [ ] On a page where custom context configuration exists (custom selectors and/or vars), reload the page and verify that a floating **Auto Fill** button appears in the bottom‑right corner by default.
+- [ ] In the popup **Fill** tab, change the floating button corner (e.g. to bottom-left) and confirm the on-page button moves to that corner without a full reload when it is already visible.
+- [ ] With **bottom-right** selected, confirm only **Bottom gap** and **Right gap** inputs are shown; adjust them (e.g. bottom 48, right 12) and verify the button respects those offsets from the viewport edges.
+- [ ] Switch to **top-left** and confirm only **Top gap** and **Left gap** inputs appear; previous gap values for other sides are preserved when switching corners back.
 - [ ] Confirm the button styling is modern (gradient, rounded) and remains visible above page content due to a high `z-index`.
 - [ ] Interact with typical page elements (scrolling, hovering) and verify the button remains visible and responsive.
 - [ ] On a page where no context configuration exists, reload and confirm that **no** floating Auto Fill button is injected.

--- a/content.js
+++ b/content.js
@@ -473,15 +473,13 @@ async function fillForm(_overrides = {}) {
 
 // ── Injected UI button ────────────────────────
 
-function injectButton() {
+function injectButton(settings) {
   if (document.getElementById("autoform-btn-wrap")) return;
 
   const wrap = document.createElement("div");
   wrap.id = "autoform-btn-wrap";
   wrap.style.cssText = `
     position: fixed;
-    bottom: 24px;
-    right: 24px;
     z-index: 2147483647;
     display: flex;
     flex-direction: column;
@@ -489,6 +487,7 @@ function injectButton() {
     gap: 8px;
     font-family: 'Segoe UI', system-ui, sans-serif;
   `;
+  StorageContext.applyFloatingButtonPositionStyles(wrap, settings);
 
   // Toast element
   const toast = document.createElement("div");
@@ -601,13 +600,17 @@ function waitForBody() {
   if (document.body) {
     StorageContext.getStorageContexts().then((entries) => {
       if (shouldShowInjectedButton(entries)) {
-        injectButton();
+        StorageContext.getFloatingButtonSettings().then((settings) => {
+          injectButton(settings);
+        });
         // Re-check on SPA navigation
         const obs = new MutationObserver(() => {
           if (!document.getElementById("autoform-btn-wrap")) {
             StorageContext.getStorageContexts().then((entries2) => {
               if (shouldShowInjectedButton(entries2)) {
-                injectButton();
+                StorageContext.getFloatingButtonSettings().then((settings) => {
+                  injectButton(settings);
+                });
               }
             });
           }
@@ -621,6 +624,17 @@ function waitForBody() {
 }
 
 waitForBody();
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area !== "local") return;
+  if (!changes[StorageContext.FLOATING_BTN_SETTINGS_KEY]) return;
+  const wrap = document.getElementById("autoform-btn-wrap");
+  if (!wrap) return;
+  StorageContext.applyFloatingButtonPositionStyles(
+    wrap,
+    changes[StorageContext.FLOATING_BTN_SETTINGS_KEY].newValue
+  );
+});
 
 function escapeCssAttrValue(value) {
   return String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AutoForm Filler",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Fills web forms using user-configured CSS selector → value template rules",
   "permissions": ["storage", "activeTab", "scripting"],
   "host_permissions": ["<all_urls>"],

--- a/popup.html
+++ b/popup.html
@@ -296,7 +296,7 @@
       <div class="subtitle">smart form filler</div>
     </div>
   </div>
-  <span class="badge">v1.3.1</span>
+  <span class="badge">v1.3.2</span>
 </div>
 
 <div class="tabs">
@@ -329,8 +329,37 @@
     </div>
   </div>
 
+  <div class="section-title" style="margin-bottom:8px">Floating button</div>
+  <div class="config-group">
+    <div class="config-label">Corner</div>
+    <select id="floating-btn-corner" class="config-input">
+      <option value="bottom-right">Bottom right</option>
+      <option value="bottom-left">Bottom left</option>
+      <option value="top-right">Top right</option>
+      <option value="top-left">Top left</option>
+    </select>
+  </div>
+  <div id="floating-btn-gaps" style="display:flex; gap:8px; margin-bottom:14px;">
+    <div class="config-group floating-gap-field" id="floating-gap-top-wrap" data-gap="top" style="flex:1; display:none;">
+      <div class="config-label">Top gap (px)</div>
+      <input type="number" id="floating-gap-top" class="config-input" min="0" max="999" step="1" value="24" />
+    </div>
+    <div class="config-group floating-gap-field" id="floating-gap-bottom-wrap" data-gap="bottom" style="flex:1;">
+      <div class="config-label">Bottom gap (px)</div>
+      <input type="number" id="floating-gap-bottom" class="config-input" min="0" max="999" step="1" value="24" />
+    </div>
+    <div class="config-group floating-gap-field" id="floating-gap-left-wrap" data-gap="left" style="flex:1; display:none;">
+      <div class="config-label">Left gap (px)</div>
+      <input type="number" id="floating-gap-left" class="config-input" min="0" max="999" step="1" value="24" />
+    </div>
+    <div class="config-group floating-gap-field" id="floating-gap-right-wrap" data-gap="right" style="flex:1;">
+      <div class="config-label">Right gap (px)</div>
+      <input type="number" id="floating-gap-right" class="config-input" min="0" max="999" step="1" value="24" />
+    </div>
+  </div>
+
   <div class="hint" id="hint-fill-entrypoint">
-    💡 An <strong>Auto Fill</strong> button is also injected directly on the page — look for the floating button in the bottom-right corner.
+    💡 An <strong>Auto Fill</strong> button is also injected directly on the page. Choose its corner and edge gaps below; changes apply on the next page load or immediately if the button is already visible.
   </div>
 </div>
 

--- a/popup.js
+++ b/popup.js
@@ -992,6 +992,81 @@ document.getElementById("popup-fill-btn").addEventListener("click", async () => 
     Fill Form Now`;
 });
 
+// ── Floating button position settings ─────────
+
+const floatingBtnCornerSelect = document.getElementById("floating-btn-corner");
+const floatingGapInputs = {
+  top: document.getElementById("floating-gap-top"),
+  bottom: document.getElementById("floating-gap-bottom"),
+  left: document.getElementById("floating-gap-left"),
+  right: document.getElementById("floating-gap-right"),
+};
+const floatingGapWraps = {
+  top: document.getElementById("floating-gap-top-wrap"),
+  bottom: document.getElementById("floating-gap-bottom-wrap"),
+  left: document.getElementById("floating-gap-left-wrap"),
+  right: document.getElementById("floating-gap-right-wrap"),
+};
+
+function readFloatingButtonSettingsFromForm() {
+  const corner = floatingBtnCornerSelect
+    ? floatingBtnCornerSelect.value
+    : StorageContext.DEFAULT_FLOATING_BTN_SETTINGS.corner;
+  return StorageContext.normalizeFloatingButtonSettings({
+    corner,
+    gaps: {
+      top: floatingGapInputs.top ? floatingGapInputs.top.value : undefined,
+      bottom: floatingGapInputs.bottom ? floatingGapInputs.bottom.value : undefined,
+      left: floatingGapInputs.left ? floatingGapInputs.left.value : undefined,
+      right: floatingGapInputs.right ? floatingGapInputs.right.value : undefined,
+    },
+  });
+}
+
+function updateFloatingGapFieldVisibility(corner) {
+  const axes = StorageContext.getFloatingButtonCornerAxes(corner);
+  Object.keys(floatingGapWraps).forEach((axis) => {
+    const wrap = floatingGapWraps[axis];
+    if (wrap) wrap.style.display = axes.includes(axis) ? "block" : "none";
+  });
+}
+
+function applyFloatingButtonSettingsToForm(settings) {
+  const normalized = StorageContext.normalizeFloatingButtonSettings(settings);
+  if (floatingBtnCornerSelect) floatingBtnCornerSelect.value = normalized.corner;
+  if (floatingGapInputs.top) floatingGapInputs.top.value = String(normalized.gaps.top);
+  if (floatingGapInputs.bottom) floatingGapInputs.bottom.value = String(normalized.gaps.bottom);
+  if (floatingGapInputs.left) floatingGapInputs.left.value = String(normalized.gaps.left);
+  if (floatingGapInputs.right) floatingGapInputs.right.value = String(normalized.gaps.right);
+  updateFloatingGapFieldVisibility(normalized.corner);
+}
+
+function persistFloatingButtonSettingsFromForm() {
+  const settings = readFloatingButtonSettingsFromForm();
+  StorageContext.setFloatingButtonSettings(settings, (result) => {
+    if (result && result.ok && result.settings) {
+      applyFloatingButtonSettingsToForm(result.settings);
+    }
+  });
+}
+
+if (floatingBtnCornerSelect) {
+  StorageContext.getFloatingButtonSettings().then((settings) => {
+    applyFloatingButtonSettingsToForm(settings);
+  });
+
+  floatingBtnCornerSelect.addEventListener("change", () => {
+    updateFloatingGapFieldVisibility(floatingBtnCornerSelect.value);
+    persistFloatingButtonSettingsFromForm();
+  });
+
+  Object.values(floatingGapInputs).forEach((input) => {
+    if (!input) return;
+    input.addEventListener("change", persistFloatingButtonSettingsFromForm);
+    input.addEventListener("blur", persistFloatingButtonSettingsFromForm);
+  });
+}
+
 // ── Scan button (Fields tab advanced search) ──
 
 let lastLinkedRuleRow = null;

--- a/storage-context.js
+++ b/storage-context.js
@@ -130,9 +130,113 @@
     });
   }
 
+  const FLOATING_BTN_SETTINGS_KEY = "floatingButtonSettings";
+
+  const FLOATING_BTN_CORNERS = [
+    "bottom-right",
+    "bottom-left",
+    "top-right",
+    "top-left",
+  ];
+
+  const FLOATING_BTN_CORNER_AXES = {
+    "bottom-right": ["bottom", "right"],
+    "bottom-left": ["bottom", "left"],
+    "top-right": ["top", "right"],
+    "top-left": ["top", "left"],
+  };
+
+  const DEFAULT_FLOATING_BTN_SETTINGS = {
+    corner: "bottom-right",
+    gaps: { top: 24, bottom: 24, left: 24, right: 24 },
+  };
+
+  function normalizeGapPx(value, fallback) {
+    const n = parseInt(value, 10);
+    if (!Number.isFinite(n) || n < 0) return fallback;
+    return Math.min(n, 999);
+  }
+
+  function normalizeFloatingButtonSettings(raw) {
+    const src = raw && typeof raw === "object" ? raw : {};
+    const corner = FLOATING_BTN_CORNERS.includes(src.corner)
+      ? src.corner
+      : DEFAULT_FLOATING_BTN_SETTINGS.corner;
+    const gapsSrc = src.gaps && typeof src.gaps === "object" ? src.gaps : {};
+    return {
+      corner,
+      gaps: {
+        top: normalizeGapPx(gapsSrc.top, DEFAULT_FLOATING_BTN_SETTINGS.gaps.top),
+        bottom: normalizeGapPx(gapsSrc.bottom, DEFAULT_FLOATING_BTN_SETTINGS.gaps.bottom),
+        left: normalizeGapPx(gapsSrc.left, DEFAULT_FLOATING_BTN_SETTINGS.gaps.left),
+        right: normalizeGapPx(gapsSrc.right, DEFAULT_FLOATING_BTN_SETTINGS.gaps.right),
+      },
+    };
+  }
+
+  function getFloatingButtonSettings() {
+    return new Promise((resolve) => {
+      chrome.storage.local.get([FLOATING_BTN_SETTINGS_KEY], (res) => {
+        if (chrome.runtime.lastError) {
+          resolve(normalizeFloatingButtonSettings(null));
+          return;
+        }
+        resolve(normalizeFloatingButtonSettings(res && res[FLOATING_BTN_SETTINGS_KEY]));
+      });
+    });
+  }
+
+  function setFloatingButtonSettings(settings, cb) {
+    const normalized = normalizeFloatingButtonSettings(settings);
+    chrome.storage.local.set({ [FLOATING_BTN_SETTINGS_KEY]: normalized }, () => {
+      if (typeof cb !== "function") return;
+      if (chrome.runtime.lastError) {
+        cb({ ok: false, error: storageErrorMessage(chrome.runtime.lastError) });
+        return;
+      }
+      cb({ ok: true, settings: normalized });
+    });
+  }
+
+  function getFloatingButtonCornerAxes(corner) {
+    return FLOATING_BTN_CORNER_AXES[corner] || FLOATING_BTN_CORNER_AXES["bottom-right"];
+  }
+
+  function applyFloatingButtonPositionStyles(element, settings) {
+    if (!element) return;
+    const normalized = normalizeFloatingButtonSettings(settings);
+    const { corner, gaps } = normalized;
+    element.style.top = "";
+    element.style.bottom = "";
+    element.style.left = "";
+    element.style.right = "";
+
+    if (corner === "bottom-right") {
+      element.style.bottom = `${gaps.bottom}px`;
+      element.style.right = `${gaps.right}px`;
+    } else if (corner === "bottom-left") {
+      element.style.bottom = `${gaps.bottom}px`;
+      element.style.left = `${gaps.left}px`;
+    } else if (corner === "top-right") {
+      element.style.top = `${gaps.top}px`;
+      element.style.right = `${gaps.right}px`;
+    } else if (corner === "top-left") {
+      element.style.top = `${gaps.top}px`;
+      element.style.left = `${gaps.left}px`;
+    }
+  }
+
   globalObj.StorageContext = {
     getStorageContexts,
     setStorageContexts,
     removeStorageContext,
+    FLOATING_BTN_SETTINGS_KEY,
+    FLOATING_BTN_CORNERS,
+    DEFAULT_FLOATING_BTN_SETTINGS,
+    normalizeFloatingButtonSettings,
+    getFloatingButtonSettings,
+    setFloatingButtonSettings,
+    getFloatingButtonCornerAxes,
+    applyFloatingButtonPositionStyles,
   };
 })(typeof globalThis !== "undefined" ? globalThis : window);


### PR DESCRIPTION
## Summary
- Add popup Fill tab controls to choose the injected Auto Fill button corner (bottom-right, bottom-left, top-right, top-left).
- Show edge gap inputs only for the sides relevant to the selected corner; values persist in `chrome.storage.local` and update the on-page button immediately when already visible.
- Bump extension version to **1.3.2** and update changelog, README, and manual test docs.

## Test plan
- [x] Reload extension in `chrome://extensions` and open popup Fill tab on a page with custom rules configured.
- [x] Confirm floating button appears bottom-right by default with 24px gaps.
- [x] Change corner to bottom-left and verify button moves without page reload.
- [x] With bottom-right selected, confirm only Bottom/Right gap inputs are visible; change gaps and verify button offset updates.
- [x] Switch to top-left, confirm only Top/Left inputs show; switch back and confirm prior gap values are preserved.
- [x] Click floating Auto Fill button and confirm fill + toast still work after repositioning.


Made with [Cursor](https://cursor.com)