### PR TITLE
Unified popup/side panel UI (v1.4.0–1.5.4) and fill button fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased 1.x.x] — started 2026-03-09
 
+## 1.5.4 — 2026-07-24
+
+- Fixed **Fill Form Now** (side panel / popup) showing `!` / `?` stats instead of fill counts by returning `true` from the content script async `fill` message handler so `sendResponse` completes reliably.
+
+## 1.5.3 — 2026-07-24
+
+- Replaced the Toolbar UI dropdown with a **Side Panel ↔ Pop-Up** toggle switch (knob left = side panel, right = pop-up).
+
+## 1.5.2 — 2026-07-24
+
+- Switching **Toolbar UI** to Popup now closes the side panel immediately (`chrome.sidePanel.close` when available, otherwise `window.close()`); switching to Side panel closes an open popup the same way.
+
+## 1.5.1 — 2026-07-24
+
+- Fixed MV3 Content Security Policy errors by removing inline `window.AFF_UI` scripts; popup vs side panel mode is detected from the shell page URL in `app-core.js`.
+
+## 1.5.0 — 2026-07-24
+
+- **Unified UI:** one extension with a shared `app-core.js`; choose **Popup** or **Side panel** on the Fill tab (**Toolbar UI**). Preference persists in `chrome.storage.local` and applies on the next toolbar icon click.
+- Restored classic **popup** UI (`popup.html`) alongside the side panel shell; both share rules, variables, and storage.
+- Extracted shared logic into `app-core.js`; `background.js` switches `chrome.action.setPopup` / `chrome.sidePanel` behavior at startup and when the mode changes.
+
+## 1.4.1 — 2026-07-24
+
+- Fixed context resolution when the current URL path does not match a saved pattern but shares the same hostname (e.g. `/portal` now loads a config saved for `host/external/*`), restoring rules and variables in the side panel and for the floating fill button.
+
+## 1.4.0 — 2026-07-24
+
+- Replaced the toolbar **popup** with a Chrome **Side Panel** UI (Chrome 114+); clicking the extension icon docks the panel beside the page like Tag Assistant.
+- Side panel layout uses full height with taller field scan lists; the header shows the active tab URL and refreshes when you switch tabs or navigate.
+- Autosave on the Custom tab now runs when focus moves to the page or another extension tab, not when switching between controls inside the panel.
+- Removed the in-panel **Close** control and save-on-close flow (dismiss the panel via Chrome's side panel chrome).
+
 ## 1.3.2 — 2026-07-24
 
 - Floating **Auto Fill** button corner can be chosen from the popup Fill tab (bottom-right, bottom-left, top-right, top-left).

--- a/Plans.md
+++ b/Plans.md
@@ -8,6 +8,216 @@ with goals, changes, risks, and a release checklist.
 > This `Plans.md` file is the long-lived, versioned source of truth for
 > iteration planning.
 
+## Version 1.5.4 — Fill message handler fix
+
+**Branch:** `feature/side-panel-ui`
+
+### Goals
+
+- Restore reliable fill from the side panel / popup **Fill Form Now** button.
+- Ensure fill stats (`filled` / `skipped` / `total`) update instead of showing error markers.
+
+### Shipped
+
+- `content.js` — `return true` on the async `fill` message branch so MV3 keeps the message channel open until `sendResponse` runs.
+
+### Testing & Risk
+
+- Regression: floating **Auto Fill** button (in-page) must still work independently.
+- Side panel tab targeting via `getActiveTab()` + `sendMessage` — verify on checkout / SPA pages.
+
+### Release Checklist
+
+- [x] Version **1.5.4**; CHANGELOG updated.
+- [x] Manual smoke: **Fill Form Now** returns numeric stats on a configured page.
+- [ ] Extension reloaded and smoke tested in Chrome 114+.
+
+## Version 1.5.3 — Toolbar UI toggle switch
+
+**Branch:** `feature/side-panel-ui`
+
+### Goals
+
+- Replace the Toolbar UI dropdown with a clearer **Side Panel ↔ Pop-Up** control.
+
+### Shipped
+
+- Fill tab **Toolbar UI** uses a toggle switch (knob left = side panel, right = pop-up) instead of a `<select>` dropdown.
+
+### Release Checklist
+
+- [x] Version **1.5.3**; CHANGELOG updated.
+- [ ] Manual smoke: toggle persists and applies on next toolbar click.
+
+## Version 1.5.2 — Close panel/popup on mode switch
+
+**Branch:** `feature/side-panel-ui`
+
+### Goals
+
+- Avoid two UI shells being open at once when switching toolbar mode.
+
+### Shipped
+
+- Switching to **Popup** closes the side panel immediately (`chrome.sidePanel.close` when available).
+- Switching to **Side panel** closes an open popup the same way.
+
+### Release Checklist
+
+- [x] Version **1.5.2**; CHANGELOG updated.
+- [ ] Manual smoke: switch popup ↔ side panel; only one shell visible at a time.
+
+## Version 1.5.1 — MV3 CSP fix
+
+**Branch:** `feature/side-panel-ui`
+
+### Goals
+
+- Fix Content Security Policy errors from inline scripts in popup / side panel shells.
+
+### Shipped
+
+- Removed inline `window.AFF_UI` bootstrap scripts from HTML shells.
+- `app-core.js` detects popup vs side panel mode from the shell page URL (`popup.html` / `sidepanel.html`).
+
+### Testing & Risk
+
+- CSP: no inline script violations in extension DevTools console on panel open.
+
+### Release Checklist
+
+- [x] Version **1.5.1**; CHANGELOG updated.
+- [ ] Extension loads without CSP errors in Chrome 114+.
+
+## Version 1.5.0 — Unified UI (Architecture A)
+
+**Branch:** `feature/side-panel-ui`
+
+### Goals
+
+- Keep **both** popup and side panel in one extension with shared storage and logic.
+- Let users switch toolbar UI mode from the Fill tab without export/import.
+- Single codebase: `app-core.js` + thin HTML shells.
+
+### Shipped
+
+- `app-core.js` — shared Fill / Fields / Custom logic.
+- `popup.html` + `sidepanel.html` — layout shells; `app-core.js` detects shell from page URL.
+- `background.js` — applies `uiMode` via `chrome.action.setPopup` / `chrome.sidePanel`.
+- Fill tab **Toolbar UI** selector; default **side panel**.
+- Removed monolithic `popup.js` in favor of shared `app-core.js`.
+
+### Release Checklist
+
+- [x] Architecture A implemented.
+- [x] Version **1.5.0**; README and CHANGELOG updated.
+- [ ] Manual smoke: switch popup ↔ side panel, shared configs persist.
+
+## Version 1.4.1 — Hostname context fallback
+
+**Branch:** `feature/side-panel-ui`
+
+### Goals
+
+- Load saved rules when the current URL path differs from a saved pattern but shares the same hostname.
+
+### Shipped
+
+- `context-matcher.js` — hostname-level fallback when no exact/prefix/wildcard match (e.g. `/portal` loads config saved for `host/external/*`).
+- Restores rules and variables in the side panel and for the floating fill button on sibling paths.
+
+### Testing & Risk
+
+- Multiple contexts on the same host with different path patterns — verify the best match still wins.
+
+### Release Checklist
+
+- [x] Version **1.4.1**; CHANGELOG updated.
+- [ ] Manual smoke: navigate to a sibling path and confirm rules load.
+
+## Version 1.4.0 — Side panel UI (completed)
+
+**Branch:** `feature/side-panel-ui`
+
+### Goals
+
+- Replace the toolbar **popup** with a **Chrome Side Panel** (Tag Assistant–style docked UI).
+- Keep all existing Fill / Fields / Custom functionality working from the panel.
+- Improve layout for a tall, persistent panel instead of a small fixed popup.
+- Preserve the floating **Auto Fill** button on the page as an optional entry point.
+
+### Features / Changes
+
+#### Phase 1 — Side Panel migration (MVP)
+
+1. **Manifest & background**
+   - Add `"side_panel": { "default_path": "sidepanel.html" }`.
+   - Add `"sidePanel"` permission.
+   - Add MV3 **service worker** (`background.js`) with:
+     ```js
+     chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+     ```
+   - Remove `action.default_popup` so toolbar click opens the side panel.
+   - Set `minimum_chrome_version` to `"114"` (Side Panel API baseline).
+
+2. **UI shell**
+   - Copy/adapt `popup.html` → `sidepanel.html` (or rename and update references).
+   - Copy/adapt `popup.js` → shared logic in `app-core.js` (later iteration).
+   - **CSS changes for panel layout:**
+     - `html, body { height: 100%; }` — use full panel height.
+     - Remove `width: 340px` and `max-height: 600px` constraints.
+     - Use `width: 100%` and flex column layout (header / tabs / scrollable body).
+     - Widen rule editor and Fields scan results where useful (~360–420px is typical panel width).
+
+3. **Popup-specific cleanup**
+   - Remove or repurpose **Close** button (`close-popup-btn`) — the panel is closed via Chrome chrome, not an in-UI dismiss.
+   - Review autosave-on-blur logic tuned for popup focus loss; side panel stays open while editing the page.
+
+4. **Docs & tests**
+   - Update README “Option B” from popup to side panel.
+   - Add manual test cases in `TESTS.md` for open/close, tab switch while panel open, fill from panel.
+
+#### Phase 2 — Side-panel UX improvements
+
+- **Context header:** show active tab URL / matched context name (like Tag Assistant’s “connected page”).
+- **Live tab sync:** refresh Fill stats and context when user switches tabs (listen to `chrome.tabs.onActivated` / `onUpdated`).
+- **Better vertical use:** expandable rule rows, sticky Fill action bar at bottom of panel.
+- **Optional:** keyboard shortcut to toggle panel (`chrome.commands`).
+
+#### Phase 3 — Tag Assistant–inspired enhancements (optional)
+
+- Highlight on page which selectors match when hovering a rule in the panel.
+- Inline “pick element” mode from Fields tab without closing the panel.
+- Badge on extension icon when current page has matching rules.
+
+### Architecture notes
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **Chrome Side Panel API** (recommended) | Native docked UI, persists while interacting with page, same extension context as today | Chrome 114+ only; needs background SW |
+| Injected iframe in content script | Works on older Chrome | Feels hacky, z-index/focus issues, not “native” |
+| DevTools panel | Good for dev tools | Wrong UX for end users filling forms |
+
+**Why Side Panel fits AutoForm Filler:** users configure rules while looking at the page; a popup closes on outside click and is size-limited. Tag Assistant uses the same pattern — panel stays open beside the page.
+
+**Files touched (Phase 1):** `manifest.json`, new `background.js`, `sidepanel.html`, `app-core.js` (from popup logic), `README.md`, `TESTS.md`, `CHANGELOG.md` (on ship).
+
+### Testing & Risk
+
+- **Chrome version:** Side Panel requires Chrome 114+; document in README.
+- **Tab messaging:** `getActiveTab()` + `sendMessage` must still target the browsed tab, not the panel — verify after migration.
+- **Focus / autosave:** popup blur autosave may fire differently; regression-test Custom tab edits.
+- **Floating button:** ensure it still works independently of panel open state.
+- Link to `TESTS.md` regression checklist after UI shell lands.
+
+### Release Checklist
+
+- [x] Phase 1 implemented and smoke-tested (pending manual pass).
+- [x] Version bumped to **1.4.0** (MINOR — UI/entry-point change).
+- [x] README updated to match behavior.
+- [x] Relevant test checklists reviewed/updated.
+- [ ] Extension reloaded and smoke tested in Chrome 114+.
+
 ## Version TBD
 
 ### Goals
@@ -24,4 +234,3 @@ with goals, changes, risks, and a release checklist.
 - [ ] README updated to match behavior.
 - [ ] Relevant test checklists reviewed/updated.
 - [ ] Extension reloaded and smoke tested in Chrome.
-

--- a/README.md
+++ b/README.md
@@ -19,14 +19,22 @@ You define pairs of **CSS selector → value template**, and the extension fills
 
 ### Option A — Floating button on the page
 If you have custom rules configured for the current page, a purple **\"Auto Fill\"** button is injected on the page (bottom-right by default).  
-On the popup **Fill** tab you can choose its corner (bottom-right, bottom-left, top-right, top-left) and set edge gaps in pixels for the relevant sides.  
+On the side panel **Fill** tab you can choose its corner (bottom-right, bottom-left, top-right, top-left) and set edge gaps in pixels for the relevant sides.  
 Click the button to run your rules and fill matching fields.
 
-### Option B — Extension popup
-Click the extension icon in Chrome's toolbar. The popup has three main areas:
+### Option B — Side panel or popup (your choice)
+Click the extension icon in Chrome's toolbar. On the **Fill** tab, use **Toolbar UI → Open extension as** to pick:
+- **Side panel** (default, Chrome 114+) — docked beside the page, stays open while you work.
+- **Popup** — classic compact window; closes when you click outside.
+
+The choice applies on the **next** toolbar click. Both modes share the same saved rules, variables, and contexts.
+
+The panel/popup has three main areas:
 - **Fill tab** → \"Fill Form Now\" button with **filled / skipped / total** stats for your custom rules.
 - **Fields tab** → Scan the current page by attribute (e.g. `data-automation-id`) to discover candidate elements and quickly create rules from them.
 - **Custom tab** → Define and manage your custom rules and variables.
+
+The header shows the active tab URL (side panel) and updates when you switch tabs.
 
 The extension **does not guess values automatically**. It only fills selectors and templates you define.
 
@@ -98,6 +106,7 @@ The extension no longer tries to infer or auto-map values based on attribute nam
 
 ## 🛠 Technical Notes
 
+- Requires **Chrome 114+** for the Side Panel API.
 - Works with **React, Angular, Vue** — uses native input value setters to trigger synthetic events.
 - Handles `<input>`, `<textarea>`, `<select>`, and many select-like widgets (via ARIA roles and common CSS classes).
 - Re-injects the floating button on SPA navigation (MutationObserver).

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,35 +1,57 @@
 ## Manual Test Coverage for AutoForm Filler
 
-This document describes **manual test coverage** for the current AutoForm Filler Chrome extension. It focuses on end‑to‑end behavior in the popup, injected page UI, and form‑filling logic driven by **explicit custom selector rules** (with `data-automation-id` used only for discovery, not for guessing values).
+This document describes **manual test coverage** for the current AutoForm Filler Chrome extension. It focuses on end‑to‑end behavior in the **side panel**, injected page UI, and form‑filling logic driven by **explicit custom selector rules** (with `data-automation-id` used only for discovery, not for guessing values).
 
-## Popup – Fill Tab
+**Requirements:** Chrome **114+** (Side Panel API).
 
-### Feature: Popup Header Version Badge
+## Side Panel – Fill Tab
 
-Short description: The popup header badge shows the current extension version from `manifest.json` (e.g. `v1.2.0`) and is non-clickable.
+### Feature: Side Panel Header Version Badge
 
-- [ ] With the extension loaded, open the popup and verify that the header version badge text matches `v<version>` where `<version>` is the `version` value from `manifest.json`.
-- [ ] Change the `version` in `manifest.json`, reload the extension in `chrome://extensions`, reopen the popup, and verify the header badge updates to show the new `v<version>` value.
-- [ ] Click the version badge in the popup header and confirm that nothing happens (no navigation, no new tabs, and no visible state change apart from normal focus behavior).
+Short description: The side panel header badge shows the current extension version from `manifest.json` (e.g. `v1.4.0`) and is non-clickable.
 
-### Feature: Fill Form from Popup
+- [ ] With the extension loaded, open the side panel and verify that the header version badge text matches `v<version>` where `<version>` is the `version` value from `manifest.json`.
+- [ ] Change the `version` in `manifest.json`, reload the extension in `chrome://extensions`, reopen the side panel, and verify the header badge updates to show the new `v<version>` value.
+- [ ] Click the version badge in the side panel header and confirm that nothing happens (no navigation, no new tabs, and no visible state change apart from normal focus behavior).
 
-Short description: Trigger a fill run for the active tab using the popup `Fill Form Now` button and show summary stats, based solely on configured custom selector rules.
+### Feature: Active Tab URL in Header
 
-- [ ] On a page where you have configured several custom selector rules (including text fields and select‑like widgets), open the popup and click **Fill Form Now**; verify that only fields covered by those rules are populated and that no unrelated fields are touched.
-- [ ] After a successful fill, verify that **Filled**, **Skipped**, and **Total** counters in the popup show non‑placeholder numeric values that roughly match the visible fields.
-- [ ] On a page with **no** matching `data-automation-id` fields, click **Fill Form Now** and verify that the stats show either `0` filled or special markers and do not crash the popup.
+Short description: The side panel header subtitle shows a truncated label for the active browser tab and updates when tabs change.
+
+- [ ] Open the side panel on a normal HTTPS page and verify the header subtitle shows hostname + path (not the full chrome:// URL).
+- [ ] Switch to another browser tab and confirm the subtitle updates to the new page within a short delay.
+- [ ] Navigate within the same tab (SPA or full reload) and confirm the subtitle updates when the URL changes.
+
+### Feature: Fill Form from Side Panel
+
+Short description: Trigger a fill run for the active tab using the side panel **Fill Form Now** button and show summary stats, based solely on configured custom selector rules.
+
+- [ ] On a page where you have configured several custom selector rules (including text fields and select‑like widgets), open the side panel and click **Fill Form Now**; verify that only fields covered by those rules are populated and that no unrelated fields are touched.
+- [ ] After a successful fill, verify that **Filled**, **Skipped**, and **Total** counters in the side panel show non‑placeholder numeric values that roughly match the visible fields.
+- [ ] On a page with **no** matching `data-automation-id` fields, click **Fill Form Now** and verify that the stats show either `0` filled or special markers and do not crash the side panel.
 - [ ] Confirm that repeated clicks on **Fill Form Now** continue to work without UI freezing, and stats update each time.
 - [ ] Verify that the fill button shows a temporary “Filling…” state (disabled) and returns to its normal label/icon afterward.
+
+### Feature: Toolbar UI Mode (Popup vs Side Panel)
+
+Short description: User can choose how the extension opens from the toolbar; both modes share the same storage.
+
+- [ ] On the Fill tab, confirm **Toolbar UI** shows **Side Panel** and **Pop-Up** labels with a sliding toggle between them (knob left = side panel, right = pop-up).
+- [ ] With **Side panel** selected, close the UI and click the toolbar icon; verify the side panel opens.
+- [ ] Switch from **Side panel** to **Popup** on the Fill tab and confirm the side panel closes immediately; the next toolbar click opens the popup.
+- [ ] Switch from **Popup** to **Side panel** and confirm the popup closes immediately; the next toolbar click opens the side panel.
+- [ ] With **Side panel** selected, close the UI and click the toolbar icon; verify the side panel opens.
+- [ ] Save custom rules in one mode, switch modes, reopen, and verify the same rules/vars load in both UIs.
+- [ ] Reload the extension and confirm the last selected UI mode is restored.
 
 ### Feature: Fill Entry Point Hint
 
 Short description: The Fill tab hints that a floating Auto Fill button may be injected on the page.
 
-- [ ] Open the popup on a page where custom selectors are configured (see Custom Rules feature) and confirm the hint text mentions the configurable floating **Auto Fill** button and corner/gap controls on the Fill tab.
+- [ ] Open the side panel on a page where custom selectors are configured (see Custom Rules feature) and confirm the hint text mentions the configurable floating **Auto Fill** button and corner/gap controls on the Fill tab.
 - [ ] On a fresh install or a page where no context config exists, confirm the hint text is still present and does not contradict actual behavior (mark specifics as **TBD** during first test run).
 
-## Popup – Fields Tab
+## Side Panel – Fields Tab
 
 ### Feature: Attribute‑Based Field Scan
 
@@ -51,11 +73,11 @@ Short description: Detected fields are visually classified as “known” or “
 
 Short description: Clicking a field in the scan results opens or updates a custom selector rule in the Custom tab.
 
-- [ ] From the Fields tab, run a search, then click a detected field item; verify that the popup switches to the **Custom** tab.
+- [ ] From the Fields tab, run a search, then click a detected field item; verify that the side panel switches to the **Custom** tab.
 - [ ] Confirm that a new custom rule row is created or updated with a selector matching the clicked field.
 - [ ] After the bridge, verify that the selector input is focused and visible, and that any previous error message for that rule is cleared.
 
-## Popup – Custom Tab: Selector Rules
+## Side Panel – Custom Tab: Selector Rules
 
 ### Feature: Custom Selector Rules CRUD
 
@@ -90,8 +112,8 @@ Short description: Rules are validated for non‑empty selectors, non‑empty va
 
 Short description: Saving custom rules persists them per URL (without hash) using Chrome local storage.
 
-- [ ] On Page A, define at least one custom rule and click **Save Custom Setup**; close and reopen the popup on the same page and verify the rule is restored.
-- [ ] Open a different page (Page B) with a different URL, open the popup, and confirm that Page A’s rules are **not** shown by default.
+- [ ] On Page A, define at least one custom rule and click **Save Custom Setup**; close and reopen the side panel on the same page and verify the rule is restored.
+- [ ] Open a different page (Page B) with a different URL, open the side panel, and confirm that Page A’s rules are **not** shown by default.
 - [ ] On Page B, create different rules, save them, then switch back to Page A and verify that Page A’s rules are still intact and independent.
 - [ ] On a single‑page application where the URL hash changes but the base URL remains the same, confirm that rules are shared across hash‑only navigations (TBD: confirm exact expected behavior).
 
@@ -107,7 +129,7 @@ Short description: Contexts can be matched using strict or weak URL pattern mode
 - [ ] Confirm hash-only URL changes (e.g. `#sectionA` to `#sectionB`) do not break context matching.
 - [ ] Export a config and verify the JSON includes `pattern` and `matchMode`; import it back and verify the same matching behavior is restored.
 
-## Popup – Custom Tab: Variables and Templates
+## Side Panel – Custom Tab: Variables and Templates
 
 ### Feature: Built‑In and Custom Variables
 
@@ -135,31 +157,23 @@ Short description: Custom selector rules use templates and variable values to bu
 - [ ] Define a custom rule whose value template uses `{{timestamp}}` and verify that repeated fills produce different, reasonable timestamp suffixes.
 - [ ] Define custom variables of type **Random first name** and **Random last name**, use them in a template, and confirm the filled value looks like a plausible name combination.
 
-## Custom Tab – Save, Close, and Autosave Behavior
+## Custom Tab – Save and Autosave Behavior
 
 ### Feature: Save Button Behavior and Toast
 
 Short description: Explicit saves persist custom rules/vars and show a success message.
 
 - [ ] With valid custom rules and variables configured, click **Save Custom Setup** and confirm a short success toast appears (e.g. “Custom rules saved”) and then fades away.
-- [ ] After saving, close and reopen the popup on the same page and verify all rules and variables are restored and function as expected when filling.
-
-### Feature: Unsaved Changes Close Confirmation
-
-Short description: Closing the popup with unsaved changes prompts the user to save, discard, or cancel.
-
-- [ ] Modify an existing rule or variable without saving and click **Close**; verify that a confirmation panel appears asking whether to Save & Close, Leave without saving, or Cancel.
-- [ ] Choose **Cancel** and confirm the popup remains open and unsaved changes are still present.
-- [ ] Choose **Leave without saving** and confirm the popup closes; when reopened, verify that previously saved values (not the unsaved edits) are shown.
-- [ ] Choose **Save & Close** and confirm changes are persisted and restored on the next open.
+- [ ] After saving, close and reopen the side panel on the same page and verify all rules and variables are restored and function as expected when filling.
 
 ### Feature: Autosave on Blur (Custom Tab)
 
-Short description: Under safe conditions, leaving the Custom tab triggers an autosave of valid changes.
+Short description: Under safe conditions, leaving the Custom tab or clicking into the page triggers an autosave of valid changes.
 
-- [ ] With a fully completed rule and variable configuration (no empty required fields), switch focus away from the popup (e.g. click into the page) and verify changes are saved without explicitly clicking **Save Custom Setup** (TBD: confirm exact trigger timing).
-- [ ] Start editing a new variable but leave its key or value empty, then blur the popup; confirm that autosave **does not** run while the variable is incomplete.
-- [ ] With an active rule that has validation errors, blur the popup and confirm those errors prevent autosave; no partial or invalid configuration should be saved.
+- [ ] With a fully completed rule and variable configuration (no empty required fields), click into the page beside the side panel and verify changes are saved without explicitly clicking **Save Custom Setup** (TBD: confirm exact trigger timing).
+- [ ] Switch from the **Custom** tab to **Fill** or **Fields** inside the side panel with valid unsaved changes and verify autosave runs (or confirm expected behavior — TBD on first run).
+- [ ] Start editing a new variable but leave its key or value empty, then click into the page; confirm that autosave **does not** run while the variable is incomplete.
+- [ ] With an active rule that has validation errors, click into the page and confirm those errors prevent autosave; no partial or invalid configuration should be saved.
 
 ## Injected Page UI and Form Filling
 
@@ -168,7 +182,7 @@ Short description: Under safe conditions, leaving the Custom tab triggers an aut
 Short description: Inject a floating Auto Fill button on pages that have context configurations and a ready DOM.
 
 - [ ] On a page where custom context configuration exists (custom selectors and/or vars), reload the page and verify that a floating **Auto Fill** button appears in the bottom‑right corner by default.
-- [ ] In the popup **Fill** tab, change the floating button corner (e.g. to bottom-left) and confirm the on-page button moves to that corner without a full reload when it is already visible.
+- [ ] In the side panel **Fill** tab, change the floating button corner (e.g. to bottom-left) and confirm the on-page button moves to that corner without a full reload when it is already visible.
 - [ ] With **bottom-right** selected, confirm only **Bottom gap** and **Right gap** inputs are shown; adjust them (e.g. bottom 48, right 12) and verify the button respects those offsets from the viewport edges.
 - [ ] Switch to **top-left** and confirm only **Top gap** and **Left gap** inputs appear; previous gap values for other sides are preserved when switching corners back.
 - [ ] Confirm the button styling is modern (gradient, rounded) and remains visible above page content due to a high `z-index`.
@@ -189,7 +203,7 @@ Short description: Clicking the injected button runs the same custom‑rule fill
 Short description: `data-automation-id` is used to **discover** fields and build selectors, but filling itself is controlled only by custom selector rules.
 
 - [ ] Using the Fields tab with `data-automation-id` as the search attribute, scan a page and confirm that results help you create or update custom selector rules in the Custom tab.
-- [ ] Run a fill with **no custom rules configured**, even on a page rich in `data-automation-id` attributes, and verify that no fields are filled and the popup/toast clearly reports zero filled without errors.
+- [ ] Run a fill with **no custom rules configured**, even on a page rich in `data-automation-id` attributes, and verify that no fields are filled and the side panel/injected toast clearly reports zero filled without errors.
 - [ ] After adding custom rules derived from those attributes, run a fill again and confirm that only fields matched by your selectors are filled; fields that merely have `data-automation-id` but no corresponding rules remain unchanged.
 
 ### Feature: Phone Country Code Select‑Like Dropdowns
@@ -219,7 +233,7 @@ Short description: Fill only text‑like and select inputs; skip unsupported typ
 
 Short description: Field fills are staggered with small delays between individual operations to avoid interaction issues, while preserving correct final values and UX.
 
-- [ ] On a typical multi‑field form (first/last name, email, phone, address, etc.), trigger a fill (popup or injected button) and visually confirm that fields appear to fill in sequence with a slight delay, but all expected fields end up correctly populated and the final **Filled/Skipped/Total** counts match the visible result.
+- [ ] On a typical multi‑field form (first/last name, email, phone, address, etc.), trigger a fill (side panel or injected button) and visually confirm that fields appear to fill in sequence with a slight delay, but all expected fields end up correctly populated and the final **Filled/Skipped/Total** counts match the visible result.
 - [ ] On a page with client‑side validation that fires on `input`/`change`/`blur`, run a fill and verify that:
   - No validation errors remain on required fields that the extension filled.
   - Any validation messages that appear while fields are filling resolve once the delayed filling completes.
@@ -227,7 +241,7 @@ Short description: Field fills are staggered with small delays between individua
   - The delayed filling does not get “ahead” of the DOM (no attempts to fill fields that are not yet present).
   - Newly mounted fields that match known patterns or custom selectors are eventually filled once they appear, or are clearly counted as skipped with logging if they cannot be reached.
 - [ ] While a fill is in progress, attempt light user interaction (scrolling, moving focus) and confirm there are no visible race conditions such as values being overwritten after manual edits, stalled toasts, or stuck loading states.
-- [ ] Run repeated fills on the same page and confirm that delays do not accumulate or cause the popup/injected button to remain disabled after completion.
+- [ ] Run repeated fills on the same page and confirm that delays do not accumulate or cause the side panel/injected button to remain disabled after completion.
 
 ### Feature: Logging and Diagnostics (Console)
 
@@ -264,9 +278,9 @@ Short description: Custom selector rules are applied in two passes: a first pass
   - Which selectors were filled on the first pass vs. second pass (TBD: exact labels/columns).
   - Which selectors failed after both passes, along with reasons (e.g. “element not found”, “element not typable”).
 - [ ] Confirm that selectors that fail even after the second pass are:
-  - Counted as **skipped** in the popup and injected toast summaries.
+  - Counted as **skipped** in the side panel and injected toast summaries.
   - Included in the total selector count so the user can reconcile the numbers.
-- [ ] Trigger fills from both the popup and the injected Auto Fill button and verify that both entry points await the full two‑pass process before showing final **Filled/Skipped/Total** counts and re‑enabling their UI controls.
+- [ ] Trigger fills from both the side panel and the injected Auto Fill button and verify that both entry points await the full two‑pass process before showing final **Filled/Skipped/Total** counts and re‑enabling their UI controls.
 
 ## Import/Export and Storage Behavior
 
@@ -282,7 +296,7 @@ Short description: Download a JSON file containing custom selectors and variable
 Short description: Upload a JSON file to replace the current context’s custom selectors and variables.
 
 - [ ] Start from a clean state, click **Upload JSON**, select a previously exported `autoform-config.json`, and confirm that rules and variables are rendered to match the file.
-- [ ] Modify the imported JSON to add or remove rules and variables, import again, and verify the popup reflects the new configuration.
+- [ ] Modify the imported JSON to add or remove rules and variables, import again, and verify the side panel reflects the new configuration.
 - [ ] Attempt to import blatantly invalid JSON (e.g. a text file); confirm that parsing failures are handled gracefully (e.g. console error, input reset) and the existing configuration is not silently corrupted.
 
 ### Feature: Local Storage Scope
@@ -291,7 +305,7 @@ Short description: Use `chrome.storage.local` to persist configs per browser pro
 
 - [ ] After saving custom rules/vars for a context, restart the browser and revisit the same URL; verify that the configuration is restored from local storage.
 - [ ] In DevTools → Application → Extension storage, confirm each context appears under its own `contextEntry:<id>` key plus a `contextEntryIds` index (not a single large `contextEntries` blob).
-- [ ] Import or save **5 or more** distinct context configurations, close and reopen the popup, and verify all contexts persist (regression for the former sync 8 KB per-item limit).
+- [ ] Import or save **5 or more** distinct context configurations, close and reopen the side panel, and verify all contexts persist (regression for the former sync 8 KB per-item limit).
 
 ### Feature: Storage Save Error Handling
 
@@ -309,7 +323,7 @@ Use this checklist when making changes to core form‑filling logic in `content.
 - [ ] Delayed/staggered filling:
   - [ ] All previously supported field types still end up filled correctly despite per‑field delays.
   - [ ] SPA/validation flows that depend on field events continue to work and do not show persistent errors after a fill.
-  - [ ] Popup and injected button remain responsive and show accurate final **Filled/Skipped/Total** counts.
+  - [ ] Side panel and injected button remain responsive and show accurate final **Filled/Skipped/Total** counts.
 - [ ] Two‑pass custom selector fill:
   - [ ] First pass still fills all straightforward, reachable custom selector targets.
   - [ ] Second pass reliably retries only initially empty fields that remain present and can now be filled.
@@ -317,9 +331,9 @@ Use this checklist when making changes to core form‑filling logic in `content.
 
 ## Tester Rules
 
-- **Keep coverage aligned with code and UI**: When features or flows change in `popup.html`, `popup.js`, `content.js`, or `manifest.json`, update or add the corresponding feature sections and checklists in this document.
+- **Keep coverage aligned with code and UI**: When features or flows change in `popup.html`, `sidepanel.html`, `app-core.js`, `content.js`, or `manifest.json`, update or add the corresponding feature sections and checklists in this document.
 - **Update existing cases before adding new ones**: When users report confusion about a test, prefer clarifying or refining the existing checklist items instead of adding near‑duplicates.
 - **Mark uncertainty as `TBD`**: If expected behavior is unclear from the implementation or UX, annotate checklist items or notes with `TBD` rather than guessing; revisit and refine once behavior is confirmed.
-- **Group tests logically**: Add new features under the most relevant group (e.g. Popup tabs, Custom rules, Injected UI, Storage) and maintain concise, action‑oriented checklists.
+- **Group tests logically**: Add new features under the most relevant group (e.g. Side panel tabs, Custom rules, Injected UI, Storage) and maintain concise, action‑oriented checklists.
 - **Avoid implementation detail coupling**: Write tests in terms of user‑visible behavior (button labels, visible outcomes) rather than internal function names, so tests remain stable as code is refactored.
 

--- a/app-core.js
+++ b/app-core.js
@@ -1,3 +1,22 @@
+// Shared UI logic for popup and side panel shells (see popup.html / sidepanel.html).
+function detectUiShellFromPage() {
+  const path =
+    typeof location !== "undefined" && location.pathname ? location.pathname : "";
+  if (/popup\.html$/i.test(path)) {
+    return { mode: "popup", tabSync: false };
+  }
+  if (/sidepanel\.html$/i.test(path)) {
+    return { mode: "sidepanel", tabSync: true };
+  }
+  return { mode: "sidepanel", tabSync: true };
+}
+
+const AFF_UI = Object.assign(
+  detectUiShellFromPage(),
+  typeof window !== "undefined" && window.AFF_UI ? window.AFF_UI : {}
+);
+const isPopupUi = AFF_UI.mode === "popup";
+
 // ── Tab switching ─────────────────────────────
 
 document.querySelectorAll(".tab").forEach((tab) => {
@@ -692,10 +711,10 @@ function renderCustomVars(vars) {
   const pills = document.getElementById("custom-vars-pills");
   if (!container) return;
 
+  const userVars = Array.isArray(vars) ? vars : [];
+
   container.innerHTML = "";
   if (pills) pills.innerHTML = "";
-
-  const userVars = Array.isArray(vars) ? vars : [];
 
   // Merge built-in vars with user-defined ones for suggestions (user vars override by key)
   const mergedByKey = {};
@@ -960,8 +979,8 @@ function renderCustomVars(vars) {
 
 // ── Fill button ───────────────────────────────
 
-document.getElementById("popup-fill-btn").addEventListener("click", async () => {
-  const btn = document.getElementById("popup-fill-btn");
+document.getElementById("fill-btn")?.addEventListener("click", async () => {
+  const btn = document.getElementById("fill-btn");
   btn.disabled = true;
   btn.textContent = "Filling…";
 
@@ -1185,9 +1204,32 @@ document.getElementById("scan-btn").addEventListener("click", async () => {
 
 // ── Custom: load saved rules/vars for context ─
 
-(async () => {
+function formatActiveTabLabel(url) {
+  if (!url) return "No active tab";
+  if (url.startsWith("chrome://") || url.startsWith("chrome-extension://")) {
+    return url.replace(/^[^:]+:\/\//, "");
+  }
+  try {
+    const parsed = new URL(url);
+    return `${parsed.hostname}${parsed.pathname}${parsed.search || ""}`;
+  } catch (_e) {
+    return url;
+  }
+}
+
+function updateActiveTabHeader(url) {
+  const el = document.getElementById("active-tab-url");
+  if (!el) return;
+  const label = formatActiveTabLabel(url);
+  el.textContent = label;
+  el.title = url || "";
+}
+
+async function reloadContextForActiveTab() {
   const tab = await getActiveTab();
   activeTabUrl = tab && tab.url ? tab.url : "";
+  updateActiveTabHeader(activeTabUrl);
+
   const entries = await StorageContext.getStorageContexts();
   const ctx = ContextMatcher.pickBestContextEntry(entries, activeTabUrl);
   const defaultPattern = ContextMatcher.canonicalPattern(activeTabUrl);
@@ -1203,7 +1245,30 @@ document.getElementById("scan-btn").addEventListener("click", async () => {
   renderCustomRules(loadedRules);
   renderCustomVars(loadedVars);
   lastSavedStateToken = getCurrentStateToken();
-})();
+}
+
+reloadContextForActiveTab();
+
+if (!isPopupUi && AFF_UI.tabSync !== false && chrome.tabs) {
+  if (chrome.tabs.onActivated) {
+    chrome.tabs.onActivated.addListener(() => {
+      reloadContextForActiveTab();
+    });
+  }
+
+  if (chrome.tabs.onUpdated) {
+    chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+      if (!changeInfo.url) return;
+      getActiveTab().then((tab) => {
+        if (tab && tab.id === tabId) reloadContextForActiveTab();
+      });
+    });
+  }
+
+  document.addEventListener("visibilitychange", () => {
+    if (!document.hidden) reloadContextForActiveTab();
+  });
+}
 
 // ── Custom selectors: add/save ────────────────
 
@@ -1632,7 +1697,7 @@ document.getElementById("add-custom-var-btn").addEventListener("click", () => {
   setActiveRuleRow(wrap);
 });
 
-// Close any open options menu when clicking elsewhere in the popup
+// Close any open options menu when clicking elsewhere in the panel
 document.addEventListener("click", () => {
   hideAllOptionMenus();
 });
@@ -1786,37 +1851,41 @@ document.getElementById("save-custom-rules-btn").addEventListener("click", async
   saveCustomSetup(true);
 });
 
-// Close / Save-or-leave confirmation
-document.getElementById("close-popup-btn").addEventListener("click", () => {
-  const panel = document.getElementById("close-confirm-panel");
-  if (!panel) {
-    window.close();
-    return;
+if (isPopupUi) {
+  const closeBtn = document.getElementById("close-popup-btn");
+  if (closeBtn) {
+    closeBtn.addEventListener("click", () => {
+      const panel = document.getElementById("close-confirm-panel");
+      if (!panel) {
+        window.close();
+        return;
+      }
+      if (!hasUnsavedChanges()) {
+        window.close();
+        return;
+      }
+      panel.style.display = "block";
+    });
   }
-  if (!hasUnsavedChanges()) {
+
+  document.getElementById("close-confirm-cancel")?.addEventListener("click", () => {
+    const panel = document.getElementById("close-confirm-panel");
+    if (panel) panel.style.display = "none";
+  });
+
+  document.getElementById("close-confirm-discard")?.addEventListener("click", () => {
     window.close();
-    return;
-  }
-  panel.style.display = "block";
-});
+  });
 
-document.getElementById("close-confirm-cancel").addEventListener("click", () => {
-  const panel = document.getElementById("close-confirm-panel");
-  if (panel) panel.style.display = "none";
-});
-
-document.getElementById("close-confirm-discard").addEventListener("click", () => {
-  window.close();
-});
-
-document.getElementById("close-confirm-save").addEventListener("click", async () => {
-  const panel = document.getElementById("close-confirm-panel");
-  const { ok } = await validateActiveRule();
-  if (!ok) return;
-  await saveCustomSetup(true);
-  if (panel) panel.style.display = "none";
-  window.close();
-});
+  document.getElementById("close-confirm-save")?.addEventListener("click", async () => {
+    const panel = document.getElementById("close-confirm-panel");
+    const { ok } = await validateActiveRule();
+    if (!ok) return;
+    await saveCustomSetup(true);
+    if (panel) panel.style.display = "none";
+    window.close();
+  });
+}
 
 // ── Import / export config as JSON ─────────────
 
@@ -2265,12 +2334,18 @@ if (contextMatchModeInput) {
       return;
     }
 
-    // If the popup window itself still has focus, treat this as an internal
-    // focus move and do not autosave. When the user clicks outside the popup
-    // or changes tab/window, document.hasFocus() becomes false and autosave
-    // will be allowed.
+    // Popup: autosave when focus leaves the popup window.
+    // Side panel: autosave when focus moves to the page or another extension tab.
     if (document.hasFocus && document.hasFocus()) {
-      return;
+      if (isPopupUi) {
+        return;
+      }
+      const nextTab = nextActive && nextActive.closest
+        ? nextActive.closest(".panel")
+        : null;
+      if (!nextTab || nextTab.id === "tab-custom") {
+        return;
+      }
     }
 
     if (autosaveTimeout) clearTimeout(autosaveTimeout);
@@ -2337,3 +2412,107 @@ if (contextMatchModeInput) {
     group.insertAdjacentElement("afterend", pills);
   });
 })();
+
+// ── Toolbar UI mode (popup vs side panel) ─────
+
+(function setupUiModeSelector() {
+  const toggle = document.getElementById("ui-mode-toggle");
+  const labelSide = document.getElementById("ui-mode-label-sidepanel");
+  const labelPopup = document.getElementById("ui-mode-label-popup");
+  const switchBtn = document.getElementById("ui-mode-switch");
+  const hint = document.getElementById("ui-mode-hint");
+  if (!toggle || !StorageContext.getUiMode) return;
+
+  let currentMode = StorageContext.UI_MODES.SIDE_PANEL;
+
+  function updateHint(mode) {
+    if (!hint) return;
+    hint.innerHTML =
+      mode === StorageContext.UI_MODES.POPUP
+        ? "Side panel closes when you switch here. Next toolbar click opens the popup."
+        : "Popup closes when you switch here. Next toolbar click opens the side panel.";
+  }
+
+  function setToggleVisual(mode) {
+    const isPopup = mode === StorageContext.UI_MODES.POPUP;
+    toggle.classList.toggle("is-popup", isPopup);
+    if (labelSide) labelSide.classList.toggle("active", !isPopup);
+    if (labelPopup) labelPopup.classList.toggle("active", isPopup);
+  }
+
+  function applyUiModeChange(mode) {
+    const switchingToPopup =
+      mode === StorageContext.UI_MODES.POPUP && !isPopupUi;
+    const switchingToSidePanel =
+      mode === StorageContext.UI_MODES.SIDE_PANEL && isPopupUi;
+
+    const sendApply = (windowId) => {
+      chrome.runtime.sendMessage(
+        { action: "applyUiMode", mode, windowId },
+        () => {
+          if (switchingToSidePanel) {
+            window.close();
+            return;
+          }
+          if (switchingToPopup) {
+            window.close();
+          }
+        }
+      );
+    };
+
+    if (switchingToPopup && chrome.windows && chrome.windows.getCurrent) {
+      chrome.windows.getCurrent((win) => {
+        sendApply(win && win.id != null ? win.id : undefined);
+      });
+      return;
+    }
+
+    sendApply(undefined);
+  }
+
+  function commitMode(mode) {
+    const normalized = normalizeUiModeSelectValue(mode);
+    if (normalized === currentMode) return;
+
+    StorageContext.setUiMode(normalized, (result) => {
+      if (!result.ok) return;
+      currentMode = normalized;
+      setToggleVisual(normalized);
+      updateHint(normalized);
+      applyUiModeChange(normalized);
+    });
+  }
+
+  StorageContext.getUiMode().then((mode) => {
+    currentMode = mode;
+    setToggleVisual(mode);
+    updateHint(mode);
+  });
+
+  if (labelSide) {
+    labelSide.addEventListener("click", () => {
+      commitMode(StorageContext.UI_MODES.SIDE_PANEL);
+    });
+  }
+  if (labelPopup) {
+    labelPopup.addEventListener("click", () => {
+      commitMode(StorageContext.UI_MODES.POPUP);
+    });
+  }
+  if (switchBtn) {
+    switchBtn.addEventListener("click", () => {
+      const next =
+        currentMode === StorageContext.UI_MODES.POPUP
+          ? StorageContext.UI_MODES.SIDE_PANEL
+          : StorageContext.UI_MODES.POPUP;
+      commitMode(next);
+    });
+  }
+})();
+
+function normalizeUiModeSelectValue(value) {
+  return value === StorageContext.UI_MODES.POPUP
+    ? StorageContext.UI_MODES.POPUP
+    : StorageContext.UI_MODES.SIDE_PANEL;
+}

--- a/background.js
+++ b/background.js
@@ -1,0 +1,77 @@
+const UI_MODES = {
+  popup: "popup",
+  sidepanel: "sidepanel",
+};
+
+function normalizeUiMode(mode) {
+  return mode === UI_MODES.popup ? UI_MODES.popup : UI_MODES.sidepanel;
+}
+
+async function closeSidePanelForWindow(windowId) {
+  if (!chrome.sidePanel || !chrome.sidePanel.close || windowId == null) {
+    return false;
+  }
+  try {
+    await chrome.sidePanel.close({ windowId });
+    return true;
+  } catch (_e) {
+    return false;
+  }
+}
+
+async function applyUiMode(mode, options) {
+  const normalized = normalizeUiMode(mode);
+  const windowId = options && options.windowId != null ? options.windowId : null;
+
+  if (normalized === UI_MODES.popup) {
+    await chrome.action.setPopup({ popup: "popup.html" });
+    if (chrome.sidePanel && chrome.sidePanel.setPanelBehavior) {
+      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
+    }
+    await closeSidePanelForWindow(windowId);
+    return normalized;
+  }
+
+  await chrome.action.setPopup({ popup: "" });
+  if (chrome.sidePanel && chrome.sidePanel.setPanelBehavior) {
+    await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+  }
+  return normalized;
+}
+
+function readStoredUiMode() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(["uiMode"], (res) => {
+      if (chrome.runtime.lastError) {
+        resolve(UI_MODES.sidepanel);
+        return;
+      }
+      resolve(normalizeUiMode(res && res.uiMode));
+    });
+  });
+}
+
+async function applyStoredUiMode() {
+  const mode = await readStoredUiMode();
+  await applyUiMode(mode);
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  applyStoredUiMode().catch(() => {});
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  applyStoredUiMode().catch(() => {});
+});
+
+applyStoredUiMode().catch(() => {});
+
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (!msg || msg.action !== "applyUiMode") return;
+  applyUiMode(msg.mode, { windowId: msg.windowId })
+    .then((mode) => sendResponse({ ok: true, mode }))
+    .catch((err) =>
+      sendResponse({ ok: false, error: err && err.message ? err.message : String(err) })
+    );
+  return true;
+});

--- a/content.js
+++ b/content.js
@@ -640,7 +640,7 @@ function escapeCssAttrValue(value) {
   return String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
-// ── Message bridge (from popup) ───────────────
+// ── Message bridge (from side panel) ───────────────
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg.action === "fill") {
@@ -657,6 +657,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
       sendResponse({ filled, skipped, total });
     })();
+    return true;
   }
   if (msg.action === "verifySelector") {
     const selector = msg.selector;

--- a/context-matcher.js
+++ b/context-matcher.js
@@ -1,4 +1,4 @@
-// Shared context URL matching + storage helpers for popup/content.
+// Shared context URL matching + storage helpers for side panel/content.
 (function attachContextMatcher(globalObj) {
   const MATCH_MODE = {
     EXACT: "exact",
@@ -169,11 +169,13 @@
     return Object.values(dedupByModePattern);
   }
 
-  function pickBestContextEntry(entries, url) {
-    const matches = (Array.isArray(entries) ? entries : []).filter((entry) =>
-      isMatch(url, entry.pattern, entry.matchMode)
-    );
-    if (!matches.length) return null;
+  function hostnameFromTarget(target) {
+    if (!target) return "";
+    const slash = target.indexOf("/");
+    return slash < 0 ? target : target.slice(0, slash);
+  }
+
+  function rankContextMatches(matches) {
     matches.sort((a, b) => {
       const pDiff = (MODE_PRIORITY[b.matchMode] || 0) - (MODE_PRIORITY[a.matchMode] || 0);
       if (pDiff !== 0) return pDiff;
@@ -182,6 +184,26 @@
       return (b.updatedAt || 0) - (a.updatedAt || 0);
     });
     return matches[0];
+  }
+
+  function pickBestContextEntry(entries, url) {
+    const list = Array.isArray(entries) ? entries : [];
+    const matches = list.filter((entry) => isMatch(url, entry.pattern, entry.matchMode));
+    if (matches.length) return rankContextMatches(matches);
+
+    // Same-hostname fallback: one config per site often covers multiple paths
+    // (e.g. /portal vs /external/* on the same host).
+    const cUrl = canonicalUrl(url);
+    const target = cUrl.replace(/^[a-z]+:\/\//i, "");
+    const urlHost = hostnameFromTarget(target);
+    if (!urlHost) return null;
+
+    const hostMatches = list.filter((entry) => {
+      const patternHost = hostnameFromTarget(canonicalPattern(entry.pattern || ""));
+      return patternHost && patternHost === urlHost;
+    });
+    if (!hostMatches.length) return null;
+    return rankContextMatches(hostMatches);
   }
 
   function saveContextEntry(entries, newEntry) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,17 +1,23 @@
 {
   "manifest_version": 3,
   "name": "AutoForm Filler",
-  "version": "1.3.2",
+  "version": "1.5.4",
+  "minimum_chrome_version": "114",
   "description": "Fills web forms using user-configured CSS selector → value template rules",
-  "permissions": ["storage", "activeTab", "scripting"],
+  "permissions": ["storage", "activeTab", "scripting", "sidePanel", "tabs"],
   "host_permissions": ["<all_urls>"],
+  "background": {
+    "service_worker": "background.js"
+  },
   "action": {
-    "default_popup": "popup.html",
     "default_icon": {
       "16": "icons/icon16.png",
       "48": "icons/icon48.png",
       "128": "icons/icon128.png"
     }
+  },
+  "side_panel": {
+    "default_path": "sidepanel.html"
   },
   "content_scripts": [
     {

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -23,14 +23,19 @@
       --radius: 10px;
     }
 
+    html, body {
+      height: 100%;
+    }
+
     body {
       font-family: 'Inter', system-ui, sans-serif;
       background: var(--bg);
       color: var(--text);
-      width: 340px;
-      min-height: 200px;
-      max-height: 600px;
-      overflow-y: auto;
+      width: 100%;
+      min-height: 100%;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
       font-size: 13px;
     }
 
@@ -60,7 +65,15 @@
     }
     .logo svg { width: 16px; height: 16px; }
     .title { font-weight: 700; font-size: 15px; letter-spacing: -0.3px; }
-    .subtitle { font-size: 10px; color: var(--muted); margin-top: 1px; }
+    .subtitle {
+      font-size: 10px;
+      color: var(--muted);
+      margin-top: 1px;
+      max-width: 220px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
     .badge {
       font-size: 9px; font-weight: 600;
       background: linear-gradient(135deg, var(--accent), var(--accent2));
@@ -87,7 +100,13 @@
     .tab.active { color: var(--accent); border-color: var(--accent); }
 
     /* Content */
-    .panel { display: none; padding: 16px 18px; }
+    .panel {
+      display: none;
+      padding: 16px 18px;
+      flex: 1;
+      min-height: 0;
+      overflow-y: auto;
+    }
     .panel.active { display: block; }
 
     /* Fill button */
@@ -158,7 +177,7 @@
       border-radius: var(--radius);
       overflow: hidden;
       margin-bottom: 14px;
-      max-height: 180px;
+      max-height: min(360px, 45vh);
       overflow-y: auto;
     }
     .field-item {
@@ -349,7 +368,7 @@
     </div>
     <div>
       <div class="title">AutoForm</div>
-      <div class="subtitle">smart form filler</div>
+      <div class="subtitle" id="active-tab-url" title="">Open a web page…</div>
     </div>
   </div>
   <span class="badge">v1.5.4</span>
@@ -500,25 +519,12 @@
 
   <button class="save-btn" id="save-custom-rules-btn">Save Custom Setup</button>
 
-  <div style="display:flex; gap:8px; margin-top:8px; justify-content:flex-end;">
-    <button class="scan-btn" id="close-popup-btn" style="flex:0 0 auto; min-width:80px;">Close</button>
-  </div>
-
   <div style="display:flex; gap:8px; margin-top:10px;">
     <button class="scan-btn" id="export-config-btn" style="flex:1;">Download JSON</button>
     <button class="scan-btn" id="open-import-btn" style="flex:1;">Upload JSON</button>
   </div>
 
   <div class="saved-toast" id="saved-toast">✓ Saved successfully</div>
-
-  <div class="hint" id="close-confirm-panel" style="margin-top:10px; display:none;">
-    <div>Save changes before closing?</div>
-    <div style="display:flex; gap:8px; margin-top:8px;">
-      <button class="save-btn" id="close-confirm-save" style="flex:1;">Save &amp; Close</button>
-      <button class="scan-btn" id="close-confirm-discard" style="flex:1;">Leave without saving</button>
-      <button class="scan-btn" id="close-confirm-cancel" style="flex:1;">Cancel</button>
-    </div>
-  </div>
 
   <div class="hint" id="import-confirm-panel" style="margin-top:10px; display:none;">
     <div><strong>Import configuration</strong></div>

--- a/storage-context.js
+++ b/storage-context.js
@@ -1,4 +1,4 @@
-// Per-entry context storage in chrome.storage.local (shared by popup/content).
+// Per-entry context storage in chrome.storage.local (shared by side panel/content).
 (function attachStorageContext(globalObj) {
   const ENTRY_IDS_KEY = "contextEntryIds";
   const ENTRY_KEY_PREFIX = "contextEntry:";
@@ -131,6 +131,12 @@
   }
 
   const FLOATING_BTN_SETTINGS_KEY = "floatingButtonSettings";
+  const UI_MODE_KEY = "uiMode";
+  const UI_MODES = {
+    POPUP: "popup",
+    SIDE_PANEL: "sidepanel",
+  };
+  const DEFAULT_UI_MODE = UI_MODES.SIDE_PANEL;
 
   const FLOATING_BTN_CORNERS = [
     "bottom-right",
@@ -226,6 +232,34 @@
     }
   }
 
+  function normalizeUiMode(mode) {
+    return mode === UI_MODES.POPUP ? UI_MODES.POPUP : UI_MODES.SIDE_PANEL;
+  }
+
+  function getUiMode() {
+    return new Promise((resolve) => {
+      chrome.storage.local.get([UI_MODE_KEY], (res) => {
+        if (chrome.runtime.lastError) {
+          resolve(DEFAULT_UI_MODE);
+          return;
+        }
+        resolve(normalizeUiMode(res && res[UI_MODE_KEY]));
+      });
+    });
+  }
+
+  function setUiMode(mode, cb) {
+    const normalized = normalizeUiMode(mode);
+    chrome.storage.local.set({ [UI_MODE_KEY]: normalized }, () => {
+      if (typeof cb !== "function") return;
+      if (chrome.runtime.lastError) {
+        cb({ ok: false, error: storageErrorMessage(chrome.runtime.lastError) });
+        return;
+      }
+      cb({ ok: true, mode: normalized });
+    });
+  }
+
   globalObj.StorageContext = {
     getStorageContexts,
     setStorageContexts,
@@ -238,5 +272,10 @@
     setFloatingButtonSettings,
     getFloatingButtonCornerAxes,
     applyFloatingButtonPositionStyles,
+    UI_MODE_KEY,
+    UI_MODES,
+    DEFAULT_UI_MODE,
+    getUiMode,
+    setUiMode,
   };
 })(typeof globalThis !== "undefined" ? globalThis : window);


### PR DESCRIPTION
## Summary
- Adds Chrome Side Panel UI (1.4.0) with live tab sync, then restores popup as a user-selectable mode via shared `app-core.js` (1.5.0).
- Patches through 1.5.4: CSP-safe shell detection, panel/popup close on mode switch, toggle UI control, hostname context fallback, and a fix for **Fill Form Now** stats (`return true` on async fill message handler).
- Updates `Plans.md` with dev notes for every shipped version in this line (1.4.0–1.5.4), plus README/TESTS/CHANGELOG.

## Test plan
- [ ] Reload extension in Chrome 114+ and open side panel on a configured checkout page.
- [ ] Click **Fill Form Now** — stats show numeric filled/skipped/total (not `!` / `?`).
- [ ] Click floating **Auto Fill** on the page — fields fill and toast appears.
- [ ] Toggle **Side Panel ↔ Pop-Up** on Fill tab; confirm only one shell opens on next toolbar click.
- [ ] Switch browser tabs while side panel is open — header URL and rules refresh.
- [ ] Navigate to a sibling path on the same host — saved rules load (1.4.1 fallback).


Made with [Cursor](https://cursor.com)